### PR TITLE
Add public API endpoints with filtering and search

### DIFF
--- a/apps/api/app/Http/Controllers/Api/PostController.php
+++ b/apps/api/app/Http/Controllers/Api/PostController.php
@@ -1,0 +1,160 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Resources\PostResource;
+use App\Http\Resources\PostSummaryResource;
+use App\Models\Post;
+use App\Traits\ApiResponse;
+use App\Traits\HandlesQueryFilters;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+
+class PostController extends Controller
+{
+    use ApiResponse;
+    use HandlesQueryFilters;
+
+    public function index(Request $request)
+    {
+        $request->validate([
+            'search' => ['nullable', 'string', 'max:255'],
+            'per_page' => ['nullable', 'integer', 'min:1', 'max:50'],
+            'sort' => ['nullable', 'string', 'max:50'],
+        ]);
+
+        $perPage = $this->resolvePerPage($request, 12, 50);
+        $searchTerm = $request->query('search');
+        $statuses = $this->resolveStatuses($request, ['draft', 'published'], ['published']);
+        $tagFilters = $this->parseListInput($request, 'tag', 'tags');
+        $seriesFilters = $this->parseListInput($request, 'series');
+        [$sortColumn, $sortDirection] = $this->resolveSort($request->query('sort'), [
+            'published_at' => 'posts.published_at',
+            'created_at' => 'posts.created_at',
+            'title' => 'posts.title',
+        ], ['posts.published_at', 'desc', 'published_at']);
+
+        $query = Post::query()
+            ->with([
+                'tags:id,name,slug',
+                'series:id,title,slug,description',
+            ]);
+
+        if ($statuses === ['published']) {
+            $query->published();
+        } else {
+            $query->where(function (Builder $builder) use ($statuses) {
+                $first = true;
+
+                if (in_array('draft', $statuses, true)) {
+                    $builder->where('status', 'draft');
+                    $first = false;
+                }
+
+                if (in_array('published', $statuses, true)) {
+                    $builder->{ $first ? 'where' : 'orWhere' }(fn (Builder $published) => $published->published());
+                }
+            });
+        }
+
+        if (! empty($tagFilters)) {
+            $tagIds = [];
+            $tagSlugs = [];
+            foreach ($tagFilters as $tag) {
+                if (is_numeric($tag)) {
+                    $tagIds[] = (int) $tag;
+                } else {
+                    $tagSlugs[] = $tag;
+                }
+            }
+
+            $query->whereHas('tags', function (Builder $tagQuery) use ($tagIds, $tagSlugs) {
+                $tagQuery->where(function (Builder $builder) use ($tagIds, $tagSlugs) {
+                    $hasCondition = false;
+
+                    if (! empty($tagIds)) {
+                        $builder->whereIn('tags.id', $tagIds);
+                        $hasCondition = true;
+                    }
+
+                    if (! empty($tagSlugs)) {
+                        $builder->{ $hasCondition ? 'orWhereIn' : 'whereIn' }('tags.slug', $tagSlugs);
+                    }
+                });
+            });
+        }
+
+        if (! empty($seriesFilters)) {
+            $seriesIds = [];
+            $seriesSlugs = [];
+
+            foreach ($seriesFilters as $series) {
+                if (is_numeric($series)) {
+                    $seriesIds[] = (int) $series;
+                } else {
+                    $seriesSlugs[] = $series;
+                }
+            }
+
+            $query->whereHas('series', function (Builder $seriesQuery) use ($seriesIds, $seriesSlugs) {
+                $seriesQuery->where(function (Builder $builder) use ($seriesIds, $seriesSlugs) {
+                    $hasCondition = false;
+
+                    if (! empty($seriesIds)) {
+                        $builder->whereIn('series.id', $seriesIds);
+                        $hasCondition = true;
+                    }
+
+                    if (! empty($seriesSlugs)) {
+                        $builder->{ $hasCondition ? 'orWhereIn' : 'whereIn' }('series.slug', $seriesSlugs);
+                    }
+                });
+            });
+        }
+
+        if ($searchTerm) {
+            $query->where(function (Builder $builder) use ($searchTerm) {
+                $builder
+                    ->where('title', 'like', "%{$searchTerm}%")
+                    ->orWhere('excerpt', 'like', "%{$searchTerm}%")
+                    ->orWhere('body_md', 'like', "%{$searchTerm}%");
+            });
+        }
+
+        $query->orderBy($sortColumn, $sortDirection)
+            ->orderByDesc('posts.created_at');
+
+        $paginator = $query
+            ->paginate($perPage)
+            ->withQueryString()
+            ->through(fn (Post $post) => (new PostSummaryResource($post))->toArray($request));
+
+        return $this->paginatedResponse($paginator, 'Publicaciones obtenidas correctamente');
+    }
+
+    public function show(Request $request, Post $post)
+    {
+        $statuses = $this->resolveStatuses($request, ['draft', 'published'], ['published']);
+        $allowPublished = in_array('published', $statuses, true);
+        $allowDraft = in_array('draft', $statuses, true);
+
+        $isPublished = $post->status === 'published' && $post->published_at?->lte(now());
+        $isDraft = $post->status === 'draft';
+
+        if ((! $isPublished || ! $allowPublished) && (! $isDraft || ! $allowDraft)) {
+            return $this->errorResponse('Entrada no disponible', Response::HTTP_NOT_FOUND);
+        }
+
+        $post->load([
+            'tags:id,name,slug',
+            'series:id,title,slug,description',
+        ]);
+
+        return $this->successResponse(
+            (new PostResource($post))->toArray($request),
+            'Publicación obtenida correctamente'
+        );
+    }
+}

--- a/apps/api/app/Http/Controllers/Api/ProjectController.php
+++ b/apps/api/app/Http/Controllers/Api/ProjectController.php
@@ -1,0 +1,183 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Resources\ProjectResource;
+use App\Http\Resources\ProjectSummaryResource;
+use App\Models\Project;
+use App\Traits\ApiResponse;
+use App\Traits\HandlesQueryFilters;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+
+class ProjectController extends Controller
+{
+    use ApiResponse;
+    use HandlesQueryFilters;
+
+    public function index(Request $request)
+    {
+        $request->validate([
+            'search' => ['nullable', 'string', 'max:255'],
+            'per_page' => ['nullable', 'integer', 'min:1', 'max:50'],
+            'sort' => ['nullable', 'string', 'max:50'],
+        ]);
+
+        $perPage = $this->resolvePerPage($request, 12, 50);
+        $searchTerm = $request->query('search');
+        $statuses = $this->resolveStatuses($request, ['draft', 'published'], ['published']);
+        $tagFilters = $this->parseListInput($request, 'tag', 'tags');
+        $skillFilters = $this->parseListInput($request, 'skill', 'skills');
+        $include = $this->requestedIncludes($request, ['skills', 'tags']);
+        $featured = $this->booleanFilter($request, 'featured');
+        [$sortColumn, $sortDirection] = $this->resolveSort($request->query('sort'), [
+            'published_at' => 'projects.published_at',
+            'created_at' => 'projects.created_at',
+            'title' => 'projects.title',
+            'sort_order' => 'projects.sort_order',
+            'featured' => 'projects.featured',
+        ], ['projects.published_at', 'desc', 'published_at']);
+
+        $query = Project::query();
+
+        $relations = [];
+        if (in_array('tags', $include, true)) {
+            $relations[] = 'tags:id,name,slug';
+        }
+        if (in_array('skills', $include, true)) {
+            $relations[] = 'skills:id,name,level,sort_order,category_id';
+            $relations[] = 'skills.category:id,name,sort_order';
+        }
+
+        if (! empty($relations)) {
+            $query->with($relations);
+        }
+
+        if ($statuses === ['published']) {
+            $query->published();
+        } else {
+            $query->where(function (Builder $builder) use ($statuses) {
+                $first = true;
+
+                if (in_array('draft', $statuses, true)) {
+                    $builder->where('status', 'draft');
+                    $first = false;
+                }
+
+                if (in_array('published', $statuses, true)) {
+                    $builder->{ $first ? 'where' : 'orWhere' }(fn (Builder $published) => $published->published());
+                }
+            });
+        }
+
+        if (! empty($tagFilters)) {
+            $tagIds = [];
+            $tagSlugs = [];
+            foreach ($tagFilters as $tag) {
+                if (is_numeric($tag)) {
+                    $tagIds[] = (int) $tag;
+                } else {
+                    $tagSlugs[] = $tag;
+                }
+            }
+
+            $query->whereHas('tags', function (Builder $tagQuery) use ($tagIds, $tagSlugs) {
+                $tagQuery->where(function (Builder $builder) use ($tagIds, $tagSlugs) {
+                    $hasCondition = false;
+
+                    if (! empty($tagIds)) {
+                        $builder->whereIn('tags.id', $tagIds);
+                        $hasCondition = true;
+                    }
+
+                    if (! empty($tagSlugs)) {
+                        $builder->{ $hasCondition ? 'orWhereIn' : 'whereIn' }('tags.slug', $tagSlugs);
+                    }
+                });
+            });
+        }
+
+        if (! empty($skillFilters)) {
+            $skillIds = [];
+            $skillNames = [];
+            foreach ($skillFilters as $skill) {
+                if (is_numeric($skill)) {
+                    $skillIds[] = (int) $skill;
+                } else {
+                    $skillNames[] = $skill;
+                }
+            }
+
+            $query->whereHas('skills', function (Builder $skillQuery) use ($skillIds, $skillNames) {
+                $skillQuery->where(function (Builder $builder) use ($skillIds, $skillNames) {
+                    $hasCondition = false;
+
+                    if (! empty($skillIds)) {
+                        $builder->whereIn('skills.id', $skillIds);
+                        $hasCondition = true;
+                    }
+
+                    if (! empty($skillNames)) {
+                        $builder->{ $hasCondition ? 'orWhereIn' : 'whereIn' }('skills.name', $skillNames);
+                    }
+                });
+            });
+        }
+
+        if ($featured !== null) {
+            $query->where('featured', $featured);
+        }
+
+        if ($searchTerm) {
+            $query->where(function (Builder $builder) use ($searchTerm) {
+                $builder
+                    ->where('title', 'like', "%{$searchTerm}%")
+                    ->orWhere('summary', 'like', "%{$searchTerm}%")
+                    ->orWhere('body_md', 'like', "%{$searchTerm}%");
+            });
+        }
+
+        if ($sortColumn === 'projects.published_at' && $sortDirection === 'desc') {
+            $query->orderByDesc('projects.featured')
+                ->orderBy('projects.sort_order');
+        }
+
+        $query->orderBy($sortColumn, $sortDirection)
+            ->orderByDesc('projects.created_at');
+
+        $paginator = $query
+            ->paginate($perPage)
+            ->withQueryString()
+            ->through(fn (Project $project) => (new ProjectSummaryResource($project))->toArray($request));
+
+        return $this->paginatedResponse($paginator, 'Proyectos obtenidos correctamente');
+    }
+
+    public function show(Request $request, Project $project)
+    {
+        $statuses = $this->resolveStatuses($request, ['draft', 'published'], ['published']);
+        $allowPublished = in_array('published', $statuses, true);
+        $allowDraft = in_array('draft', $statuses, true);
+
+        $isPublished = $project->status === 'published' && $project->published_at?->lte(now());
+        $isDraft = $project->status === 'draft';
+
+        if ((! $isPublished || ! $allowPublished) && (! $isDraft || ! $allowDraft)) {
+            return $this->errorResponse('Proyecto no disponible', Response::HTTP_NOT_FOUND);
+        }
+
+        $project->load([
+            'tags:id,name,slug',
+            'skills:id,name,level,sort_order,category_id',
+            'skills.category:id,name,sort_order',
+            'blocks' => fn ($query) => $query->orderBy('order_index'),
+        ]);
+
+        return $this->successResponse(
+            (new ProjectResource($project))->toArray($request),
+            'Proyecto obtenido correctamente'
+        );
+    }
+}

--- a/apps/api/app/Http/Controllers/Api/SeriesController.php
+++ b/apps/api/app/Http/Controllers/Api/SeriesController.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Resources\SeriesResource;
+use App\Models\Series;
+use App\Traits\ApiResponse;
+use App\Traits\HandlesQueryFilters;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Http\Request;
+
+class SeriesController extends Controller
+{
+    use ApiResponse;
+    use HandlesQueryFilters;
+
+    public function index(Request $request)
+    {
+        $request->validate([
+            'search' => ['nullable', 'string', 'max:255'],
+            'per_page' => ['nullable', 'integer', 'min:1', 'max:100'],
+            'sort' => ['nullable', 'string', 'max:50'],
+        ]);
+
+        $perPage = $this->resolvePerPage($request, 15, 100);
+        $searchTerm = $request->query('search');
+        $includeCounts = $this->booleanFilter($request, 'include_counts') ?? false;
+        [$sortColumn, $sortDirection] = $this->resolveSort($request->query('sort'), [
+            'title' => 'series.title',
+            'created_at' => 'series.created_at',
+            'sort_order' => 'series.sort_order',
+        ], ['series.sort_order', 'asc', 'sort_order']);
+
+        $query = Series::query();
+
+        if ($includeCounts) {
+            $query->withCount([
+                'posts as published_posts_count' => fn ($q) => $q->published(),
+            ]);
+        }
+
+        if ($searchTerm) {
+            $query->where(function (Builder $builder) use ($searchTerm) {
+                $builder
+                    ->where('title', 'like', "%{$searchTerm}%")
+                    ->orWhere('description', 'like', "%{$searchTerm}%");
+            });
+        }
+
+        $query->orderBy($sortColumn, $sortDirection)
+            ->orderBy('series.title');
+
+        $paginator = $query
+            ->paginate($perPage)
+            ->withQueryString()
+            ->through(fn (Series $series) => (new SeriesResource($series))->toArray($request));
+
+        return $this->paginatedResponse($paginator, 'Series obtenidas correctamente');
+    }
+
+    public function show(Request $request, Series $series)
+    {
+        $include = $this->requestedIncludes($request, ['posts']);
+
+        if (in_array('posts', $include, true)) {
+            $series->load(['posts' => function ($query) {
+                $query->published()
+                    ->with(['tags:id,name,slug', 'series:id,title,slug'])
+                    ->orderByDesc('published_at');
+            }]);
+        }
+
+        $series->loadCount([
+            'posts as published_posts_count' => fn ($q) => $q->published(),
+        ]);
+
+        return $this->successResponse(
+            (new SeriesResource($series))->toArray($request),
+            'Serie obtenida correctamente'
+        );
+    }
+}

--- a/apps/api/app/Http/Controllers/Api/SkillController.php
+++ b/apps/api/app/Http/Controllers/Api/SkillController.php
@@ -3,47 +3,126 @@
 namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
+use App\Http\Resources\SkillResource;
+use App\Models\Skill;
+use App\Traits\ApiResponse;
+use App\Traits\HandlesQueryFilters;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\Request;
 
 class SkillController extends Controller
 {
-    /**
-     * Display a listing of the resource.
-     */
-    public function index()
+    use ApiResponse;
+    use HandlesQueryFilters;
+
+    public function index(Request $request)
     {
-        //
+        $request->validate([
+            'search' => ['nullable', 'string', 'max:120'],
+            'per_page' => ['nullable', 'integer', 'min:1', 'max:100'],
+            'sort' => ['nullable', 'string', 'max:50'],
+        ]);
+
+        $perPage = $this->resolvePerPage($request, 50, 100);
+        $searchTerm = $request->query('search');
+        $categoryFilters = $this->parseListInput($request, 'category', 'categories');
+        $include = $this->requestedIncludes($request, ['category']);
+        $includeCounts = $this->booleanFilter($request, 'include_counts') ?? false;
+        [$sortColumn, $sortDirection] = $this->resolveSort($request->query('sort'), [
+            'name' => 'skills.name',
+            'level' => 'skills.level',
+            'sort_order' => 'skills.sort_order',
+            'created_at' => 'skills.created_at',
+        ], ['skills.sort_order', 'asc', 'sort_order']);
+
+        $query = Skill::query();
+
+        if (in_array('category', $include, true)) {
+            $query->with('category:id,name,sort_order');
+        }
+
+        if ($includeCounts) {
+            $query->withCount([
+                'projects as published_projects_count' => fn ($q) => $q->published(),
+            ]);
+        }
+
+        if (! empty($categoryFilters)) {
+            $query->where(function (Builder $builder) use ($categoryFilters) {
+                $ids = [];
+                $names = [];
+                $withNull = false;
+
+                foreach ($categoryFilters as $filter) {
+                    if (is_numeric($filter)) {
+                        $ids[] = (int) $filter;
+                        continue;
+                    }
+
+                    $normalized = strtolower($filter);
+                    if (in_array($normalized, ['none', 'null'], true)) {
+                        $withNull = true;
+                        continue;
+                    }
+
+                    $names[] = $filter;
+                }
+
+                $first = true;
+
+                if (! empty($ids)) {
+                    $builder->whereIn('category_id', $ids);
+                    $first = false;
+                }
+
+                if (! empty($names)) {
+                    $builder->{ $first ? 'whereHas' : 'orWhereHas' }('category', function (Builder $categoryQuery) use ($names) {
+                        $categoryQuery->whereIn('name', $names);
+                    });
+                    $first = false;
+                }
+
+                if ($withNull) {
+                    $builder->{ $first ? 'whereNull' : 'orWhereNull' }('category_id');
+                }
+            });
+        }
+
+        if ($searchTerm) {
+            $query->where('name', 'like', "%{$searchTerm}%");
+        }
+
+        $query->orderBy($sortColumn, $sortDirection)
+            ->orderBy('skills.name');
+
+        $paginator = $query
+            ->paginate($perPage)
+            ->withQueryString()
+            ->through(fn (Skill $skill) => (new SkillResource($skill))->toArray($request));
+
+        return $this->paginatedResponse($paginator, 'Habilidades obtenidas correctamente');
     }
 
-    /**
-     * Store a newly created resource in storage.
-     */
-    public function store(Request $request)
+    public function show(Request $request, Skill $skill)
     {
-        //
-    }
+        $include = $this->requestedIncludes($request, ['category', 'projects']);
+        $skill->loadMissing('category:id,name,sort_order');
 
-    /**
-     * Display the specified resource.
-     */
-    public function show(string $id)
-    {
-        //
-    }
+        if (in_array('projects', $include, true)) {
+            $skill->load(['projects' => function ($query) {
+                $query->published()
+                    ->with(['tags:id,name,slug', 'skills:id,name'])
+                    ->orderByDesc('published_at');
+            }]);
+        }
 
-    /**
-     * Update the specified resource in storage.
-     */
-    public function update(Request $request, string $id)
-    {
-        //
-    }
+        $skill->loadCount([
+            'projects as published_projects_count' => fn ($q) => $q->published(),
+        ]);
 
-    /**
-     * Remove the specified resource from storage.
-     */
-    public function destroy(string $id)
-    {
-        //
+        return $this->successResponse(
+            (new SkillResource($skill))->toArray($request),
+            'Habilidad obtenida correctamente'
+        );
     }
 }

--- a/apps/api/app/Http/Controllers/Api/TagController.php
+++ b/apps/api/app/Http/Controllers/Api/TagController.php
@@ -3,47 +3,104 @@
 namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
+use App\Http\Resources\TagResource;
+use App\Models\Tag;
+use App\Traits\ApiResponse;
+use App\Traits\HandlesQueryFilters;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\Request;
 
 class TagController extends Controller
 {
-    /**
-     * Display a listing of the resource.
-     */
-    public function index()
+    use ApiResponse;
+    use HandlesQueryFilters;
+
+    public function index(Request $request)
     {
-        //
+        $request->validate([
+            'search' => ['nullable', 'string', 'max:180'],
+            'per_page' => ['nullable', 'integer', 'min:1', 'max:100'],
+            'sort' => ['nullable', 'string', 'max:50'],
+            'type' => ['nullable', 'string', 'max:20'],
+        ]);
+
+        $perPage = $this->resolvePerPage($request, 30, 100);
+        $searchTerm = $request->query('search');
+        $type = strtolower((string) $request->query('type', ''));
+        $includeCounts = $this->booleanFilter($request, 'include_counts') ?? false;
+        [$sortColumn, $sortDirection] = $this->resolveSort($request->query('sort'), [
+            'name' => 'tags.name',
+            'created_at' => 'tags.created_at',
+            'updated_at' => 'tags.updated_at',
+        ], ['tags.name', 'asc', 'name']);
+
+        $query = Tag::query();
+
+        if ($includeCounts) {
+            $query->withCount([
+                'posts as published_posts_count' => fn ($q) => $q->published(),
+                'projects as published_projects_count' => fn ($q) => $q->published(),
+            ]);
+        }
+
+        if ($type === 'posts') {
+            $query->whereHas('posts', fn (Builder $q) => $q->published());
+        } elseif ($type === 'projects') {
+            $query->whereHas('projects', fn (Builder $q) => $q->published());
+        }
+
+        if ($searchTerm) {
+            $query->where(function (Builder $builder) use ($searchTerm) {
+                $builder
+                    ->where('name', 'like', "%{$searchTerm}%")
+                    ->orWhere('slug', 'like', "%{$searchTerm}%");
+            });
+        }
+
+        $query->orderBy($sortColumn, $sortDirection)
+            ->orderBy('tags.slug');
+
+        $paginator = $query
+            ->paginate($perPage)
+            ->withQueryString()
+            ->through(fn (Tag $tag) => (new TagResource($tag))->toArray($request));
+
+        return $this->paginatedResponse($paginator, 'Etiquetas obtenidas correctamente');
     }
 
-    /**
-     * Store a newly created resource in storage.
-     */
-    public function store(Request $request)
+    public function show(Request $request, Tag $tag)
     {
-        //
-    }
+        $include = $this->requestedIncludes($request, ['posts', 'projects']);
 
-    /**
-     * Display the specified resource.
-     */
-    public function show(string $id)
-    {
-        //
-    }
+        $tag->loadCount([
+            'posts as published_posts_count' => fn ($q) => $q->published(),
+            'projects as published_projects_count' => fn ($q) => $q->published(),
+        ]);
 
-    /**
-     * Update the specified resource in storage.
-     */
-    public function update(Request $request, string $id)
-    {
-        //
-    }
+        if (in_array('posts', $include, true)) {
+            $tag->load(['posts' => function ($query) {
+                $query->published()
+                    ->with(['tags:id,name,slug', 'series:id,title,slug'])
+                    ->orderByDesc('published_at');
+            }]);
+        }
 
-    /**
-     * Remove the specified resource from storage.
-     */
-    public function destroy(string $id)
-    {
-        //
+        if (in_array('projects', $include, true)) {
+            $tag->load(['projects' => function ($query) {
+                $query->published()
+                    ->with([
+                        'tags:id,name,slug',
+                        'skills:id,name,level,sort_order,category_id',
+                        'skills.category:id,name,sort_order',
+                    ])
+                    ->orderByDesc('published_at')
+                    ->orderBy('sort_order');
+            }]);
+        }
+
+        return $this->successResponse(
+            (new TagResource($tag))->toArray($request),
+            'Etiqueta obtenida correctamente'
+        );
     }
 }

--- a/apps/api/app/Http/Resources/PostResource.php
+++ b/apps/api/app/Http/Resources/PostResource.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Http\Resources;
+
+class PostResource extends PostSummaryResource
+{
+    public function toArray($request): array
+    {
+        $data = parent::toArray($request);
+
+        $data['body'] = $this->body_md;
+        $data['og_image_url'] = $this->og_image_url;
+
+        return $data;
+    }
+}

--- a/apps/api/app/Http/Resources/PostSummaryResource.php
+++ b/apps/api/app/Http/Resources/PostSummaryResource.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class PostSummaryResource extends JsonResource
+{
+    public function toArray($request): array
+    {
+        return [
+            'id' => $this->id,
+            'title' => $this->title,
+            'slug' => $this->slug,
+            'excerpt' => $this->excerpt,
+            'status' => $this->status,
+            'published_at' => optional($this->published_at)->toIso8601String(),
+            'series' => $this->when($this->relationLoaded('series') && $this->series, function () use ($request) {
+                return [
+                    'id' => $this->series->id,
+                    'title' => $this->series->title,
+                    'slug' => $this->series->slug,
+                    'description' => $this->series->description,
+                ];
+            }),
+            'tags' => $this->when($this->relationLoaded('tags'), function () use ($request) {
+                return $this->tags->map(fn ($tag) => (new TagResource($tag))->toArray($request))->all();
+            }),
+            'created_at' => optional($this->created_at)->toIso8601String(),
+            'updated_at' => optional($this->updated_at)->toIso8601String(),
+        ];
+    }
+}

--- a/apps/api/app/Http/Resources/ProjectBlockResource.php
+++ b/apps/api/app/Http/Resources/ProjectBlockResource.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class ProjectBlockResource extends JsonResource
+{
+    public function toArray($request): array
+    {
+        return [
+            'id' => $this->id,
+            'type' => $this->type,
+            'order' => (int) $this->order_index,
+            'data' => $this->data_json,
+        ];
+    }
+}

--- a/apps/api/app/Http/Resources/ProjectResource.php
+++ b/apps/api/app/Http/Resources/ProjectResource.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Resources;
+
+class ProjectResource extends ProjectSummaryResource
+{
+    public function toArray($request): array
+    {
+        $data = parent::toArray($request);
+
+        $data['body'] = $this->body_md;
+        $data['og_image_url'] = $this->og_image_url;
+        $data['blocks'] = $this->when($this->relationLoaded('blocks'), function () use ($request) {
+            return $this->blocks
+                ->sortBy('order_index')
+                ->values()
+                ->map(fn ($block) => (new ProjectBlockResource($block))->toArray($request))
+                ->all();
+        });
+
+        return $data;
+    }
+}

--- a/apps/api/app/Http/Resources/ProjectSummaryResource.php
+++ b/apps/api/app/Http/Resources/ProjectSummaryResource.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class ProjectSummaryResource extends JsonResource
+{
+    public function toArray($request): array
+    {
+        return [
+            'id' => $this->id,
+            'title' => $this->title,
+            'slug' => $this->slug,
+            'summary' => $this->summary,
+            'featured' => (bool) $this->featured,
+            'sort_order' => (int) $this->sort_order,
+            'status' => $this->status,
+            'repo_url' => $this->repo_url,
+            'demo_url' => $this->demo_url,
+            'published_at' => optional($this->published_at)->toIso8601String(),
+            'tags' => $this->when($this->relationLoaded('tags'), function () use ($request) {
+                return $this->tags->map(fn ($tag) => (new TagResource($tag))->toArray($request))->all();
+            }),
+            'skills' => $this->when($this->relationLoaded('skills'), function () use ($request) {
+                return $this->skills->map(fn ($skill) => (new SkillSummaryResource($skill))->toArray($request))->all();
+            }),
+            'created_at' => optional($this->created_at)->toIso8601String(),
+            'updated_at' => optional($this->updated_at)->toIso8601String(),
+        ];
+    }
+}

--- a/apps/api/app/Http/Resources/SeriesResource.php
+++ b/apps/api/app/Http/Resources/SeriesResource.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class SeriesResource extends JsonResource
+{
+    public function toArray($request): array
+    {
+        $data = [
+            'id' => $this->id,
+            'title' => $this->title,
+            'slug' => $this->slug,
+            'description' => $this->description,
+            'sort_order' => (int) $this->sort_order,
+            'created_at' => optional($this->created_at)->toIso8601String(),
+            'updated_at' => optional($this->updated_at)->toIso8601String(),
+        ];
+
+        if (isset($this->published_posts_count)) {
+            $data['posts_count'] = (int) $this->published_posts_count;
+        }
+
+        if ($this->relationLoaded('posts')) {
+            $data['posts'] = $this->posts
+                ->map(fn ($post) => (new PostSummaryResource($post))->toArray($request))
+                ->all();
+        }
+
+        return $data;
+    }
+}

--- a/apps/api/app/Http/Resources/SkillCategoryResource.php
+++ b/apps/api/app/Http/Resources/SkillCategoryResource.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class SkillCategoryResource extends JsonResource
+{
+    public function toArray($request): array
+    {
+        return [
+            'id' => $this->id,
+            'name' => $this->name,
+            'sort_order' => (int) $this->sort_order,
+        ];
+    }
+}

--- a/apps/api/app/Http/Resources/SkillResource.php
+++ b/apps/api/app/Http/Resources/SkillResource.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Resources;
+
+class SkillResource extends SkillSummaryResource
+{
+    public function toArray($request): array
+    {
+        $data = parent::toArray($request);
+
+        if (isset($this->published_projects_count)) {
+            $data['projects_count'] = (int) $this->published_projects_count;
+        }
+
+        if ($this->relationLoaded('projects')) {
+            $data['projects'] = $this->projects
+                ->map(fn ($project) => (new ProjectSummaryResource($project))->toArray($request))
+                ->all();
+        }
+
+        return $data;
+    }
+}

--- a/apps/api/app/Http/Resources/SkillSummaryResource.php
+++ b/apps/api/app/Http/Resources/SkillSummaryResource.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class SkillSummaryResource extends JsonResource
+{
+    public function toArray($request): array
+    {
+        return [
+            'id' => $this->id,
+            'name' => $this->name,
+            'level' => (int) $this->level,
+            'sort_order' => (int) $this->sort_order,
+            'category' => $this->when($this->relationLoaded('category') && $this->category, function () use ($request) {
+                return (new SkillCategoryResource($this->category))->toArray($request);
+            }),
+        ];
+    }
+}

--- a/apps/api/app/Http/Resources/TagResource.php
+++ b/apps/api/app/Http/Resources/TagResource.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class TagResource extends JsonResource
+{
+    public function toArray($request): array
+    {
+        $data = [
+            'id' => $this->id,
+            'name' => $this->name,
+            'slug' => $this->slug,
+            'created_at' => optional($this->created_at)->toIso8601String(),
+            'updated_at' => optional($this->updated_at)->toIso8601String(),
+        ];
+
+        if (isset($this->published_posts_count)) {
+            $data['posts_count'] = (int) $this->published_posts_count;
+        }
+
+        if (isset($this->published_projects_count)) {
+            $data['projects_count'] = (int) $this->published_projects_count;
+        }
+
+        if ($this->relationLoaded('posts')) {
+            $data['posts'] = $this->posts
+                ->map(fn ($post) => (new PostSummaryResource($post))->toArray($request))
+                ->all();
+        }
+
+        if ($this->relationLoaded('projects')) {
+            $data['projects'] = $this->projects
+                ->map(fn ($project) => (new ProjectSummaryResource($project))->toArray($request))
+                ->all();
+        }
+
+        return $data;
+    }
+}

--- a/apps/api/app/Models/Post.php
+++ b/apps/api/app/Models/Post.php
@@ -2,6 +2,8 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
@@ -17,6 +19,7 @@ use Spatie\Image\Enums\Fit;
 
 class Post extends Model implements HasMedia
 {
+    use HasFactory;
     use InteractsWithMedia;
 
     protected $fillable = [
@@ -58,6 +61,17 @@ class Post extends Model implements HasMedia
     public function activePreviewToken(): ?PreviewToken
     {
         return $this->previewTokens()->valid()->latest('expires_at')->first();
+    }
+
+    public function scopePublished(Builder $query): Builder
+    {
+        return $query
+            ->where('status', 'published')
+            ->where(function ($scope) {
+                $scope
+                    ->whereNull('published_at')
+                    ->orWhere('published_at', '<=', now());
+            });
     }
 
     /* -------------------------

--- a/apps/api/app/Models/Project.php
+++ b/apps/api/app/Models/Project.php
@@ -2,6 +2,8 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -9,6 +11,8 @@ use Illuminate\Database\Eloquent\Relations\MorphMany;
 
 class Project extends Model
 {
+    use HasFactory;
+
     protected $fillable = [
         'title',
         'slug',
@@ -53,5 +57,16 @@ class Project extends Model
     public function activePreviewToken(): ?PreviewToken
     {
         return $this->previewTokens()->valid()->latest('expires_at')->first();
+    }
+
+    public function scopePublished(Builder $query): Builder
+    {
+        return $query
+            ->where('status', 'published')
+            ->where(function ($scope) {
+                $scope
+                    ->whereNull('published_at')
+                    ->orWhere('published_at', '<=', now());
+            });
     }
 }

--- a/apps/api/app/Models/ProjectBlock.php
+++ b/apps/api/app/Models/ProjectBlock.php
@@ -2,11 +2,14 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class ProjectBlock extends Model
 {
+    use HasFactory;
+
     protected $fillable = [
         'project_id',
         'type',

--- a/apps/api/app/Models/Series.php
+++ b/apps/api/app/Models/Series.php
@@ -2,11 +2,14 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class Series extends Model
 {
+    use HasFactory;
+
     protected $fillable = [
         'title',
         'slug',

--- a/apps/api/app/Models/Skill.php
+++ b/apps/api/app/Models/Skill.php
@@ -2,11 +2,14 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class Skill extends Model
 {
+    use HasFactory;
+
     protected $fillable = [
         'name',
         'category_id',

--- a/apps/api/app/Models/SkillCategory.php
+++ b/apps/api/app/Models/SkillCategory.php
@@ -2,11 +2,14 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class SkillCategory extends Model
 {
+    use HasFactory;
+
     protected $fillable = [
         'name',
         'sort_order',

--- a/apps/api/app/Models/Tag.php
+++ b/apps/api/app/Models/Tag.php
@@ -2,10 +2,13 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class Tag extends Model
 {
+    use HasFactory;
+
     protected $fillable = [
         'name',
         'slug',

--- a/apps/api/app/Traits/HandlesQueryFilters.php
+++ b/apps/api/app/Traits/HandlesQueryFilters.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace App\Traits;
+
+use Illuminate\Http\Request;
+
+trait HandlesQueryFilters
+{
+    protected function parseListInput(Request $request, string $key, ?string $alternate = null): array
+    {
+        $value = $request->query($key);
+
+        if ($value === null && $alternate !== null) {
+            $value = $request->query($alternate);
+        }
+
+        if ($value === null) {
+            return [];
+        }
+
+        if (is_array($value)) {
+            $items = $value;
+        } else {
+            $items = explode(',', (string) $value);
+        }
+
+        return collect($items)
+            ->map(fn ($item) => trim((string) $item))
+            ->filter(fn ($item) => $item !== '')
+            ->values()
+            ->all();
+    }
+
+    protected function requestedIncludes(Request $request, array $allowed): array
+    {
+        $requested = $this->parseListInput($request, 'include');
+
+        return array_values(array_intersect($allowed, $requested));
+    }
+
+    protected function resolvePerPage(Request $request, int $default = 15, int $max = 50): int
+    {
+        $perPage = (int) ($request->query('per_page') ?? $default);
+
+        if ($perPage < 1) {
+            return $default;
+        }
+
+        return min($perPage, $max);
+    }
+
+    protected function resolveStatuses(Request $request, array $allowed, array $default): array
+    {
+        $values = $this->parseListInput($request, 'status');
+
+        $statuses = collect($values)
+            ->map(fn ($status) => strtolower($status))
+            ->filter(fn ($status) => in_array($status, $allowed, true))
+            ->unique()
+            ->values()
+            ->all();
+
+        return !empty($statuses) ? $statuses : $default;
+    }
+
+    protected function booleanFilter(Request $request, string $key): ?bool
+    {
+        if (! $request->has($key)) {
+            return null;
+        }
+
+        $value = $request->query($key);
+
+        if (is_bool($value)) {
+            return $value;
+        }
+
+        if (is_string($value) || is_numeric($value)) {
+            return filter_var($value, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
+        }
+
+        return null;
+    }
+
+    protected function resolveSort(?string $sort, array $allowed, array $fallback): array
+    {
+        if ($sort === null || trim($sort) === '') {
+            return [$fallback[0], $fallback[1], $fallback[2] ?? null];
+        }
+
+        $direction = str_starts_with($sort, '-') ? 'desc' : 'asc';
+        $key = ltrim($sort, '-');
+
+        if (! array_key_exists($key, $allowed)) {
+            return [$fallback[0], $fallback[1], $fallback[2] ?? null];
+        }
+
+        return [$allowed[$key], $direction, $key];
+    }
+}

--- a/apps/api/database/factories/PostFactory.php
+++ b/apps/api/database/factories/PostFactory.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Post;
+use App\Models\Series;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<Post>
+ */
+class PostFactory extends Factory
+{
+    protected $model = Post::class;
+
+    public function definition(): array
+    {
+        $title = $this->faker->unique()->sentence(4);
+
+        return [
+            'title' => $title,
+            'slug' => Str::slug($title) . '-' . Str::random(5),
+            'excerpt' => $this->faker->paragraph(),
+            'body_md' => $this->faker->paragraphs(3, true),
+            'status' => 'draft',
+            'published_at' => null,
+            'series_id' => null,
+            'og_image_url' => $this->faker->imageUrl(1200, 630, 'business', true),
+        ];
+    }
+
+    public function published(): self
+    {
+        return $this->state(fn () => [
+            'status' => 'published',
+            'published_at' => now()->subDays($this->faker->numberBetween(0, 30)),
+        ]);
+    }
+
+    public function withSeries(): self
+    {
+        return $this->state(fn () => [
+            'series_id' => Series::factory(),
+        ]);
+    }
+}

--- a/apps/api/database/factories/ProjectBlockFactory.php
+++ b/apps/api/database/factories/ProjectBlockFactory.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Project;
+use App\Models\ProjectBlock;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<ProjectBlock>
+ */
+class ProjectBlockFactory extends Factory
+{
+    protected $model = ProjectBlock::class;
+
+    public function definition(): array
+    {
+        return [
+            'project_id' => Project::factory(),
+            'type' => $this->faker->randomElement(['text', 'image', 'highlight']),
+            'data_json' => [
+                'content' => $this->faker->paragraph(),
+            ],
+            'order_index' => $this->faker->numberBetween(1, 5),
+        ];
+    }
+}

--- a/apps/api/database/factories/ProjectFactory.php
+++ b/apps/api/database/factories/ProjectFactory.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Project;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<Project>
+ */
+class ProjectFactory extends Factory
+{
+    protected $model = Project::class;
+
+    public function definition(): array
+    {
+        $title = $this->faker->unique()->sentence(3);
+
+        return [
+            'title' => $title,
+            'slug' => Str::slug($title) . '-' . Str::random(5),
+            'summary' => $this->faker->paragraph(),
+            'body_md' => $this->faker->paragraphs(4, true),
+            'repo_url' => $this->faker->url(),
+            'demo_url' => $this->faker->url(),
+            'featured' => $this->faker->boolean(20),
+            'sort_order' => $this->faker->numberBetween(1, 100),
+            'status' => 'draft',
+            'published_at' => null,
+            'og_image_url' => $this->faker->imageUrl(1200, 630, 'technics', true),
+        ];
+    }
+
+    public function published(): self
+    {
+        return $this->state(fn () => [
+            'status' => 'published',
+            'published_at' => now()->subDays($this->faker->numberBetween(0, 60)),
+        ]);
+    }
+
+    public function featured(): self
+    {
+        return $this->state(fn () => [
+            'featured' => true,
+        ]);
+    }
+}

--- a/apps/api/database/factories/SeriesFactory.php
+++ b/apps/api/database/factories/SeriesFactory.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Series;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<Series>
+ */
+class SeriesFactory extends Factory
+{
+    protected $model = Series::class;
+
+    public function definition(): array
+    {
+        $title = $this->faker->unique()->sentence(3);
+
+        return [
+            'title' => $title,
+            'slug' => Str::slug($title) . '-' . Str::random(4),
+            'description' => $this->faker->paragraph(),
+            'sort_order' => $this->faker->numberBetween(1, 50),
+        ];
+    }
+}

--- a/apps/api/database/factories/SkillCategoryFactory.php
+++ b/apps/api/database/factories/SkillCategoryFactory.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\SkillCategory;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<SkillCategory>
+ */
+class SkillCategoryFactory extends Factory
+{
+    protected $model = SkillCategory::class;
+
+    public function definition(): array
+    {
+        return [
+            'name' => ucfirst($this->faker->unique()->word()),
+            'sort_order' => $this->faker->numberBetween(1, 20),
+        ];
+    }
+}

--- a/apps/api/database/factories/SkillFactory.php
+++ b/apps/api/database/factories/SkillFactory.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Skill;
+use App\Models\SkillCategory;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Skill>
+ */
+class SkillFactory extends Factory
+{
+    protected $model = Skill::class;
+
+    public function definition(): array
+    {
+        return [
+            'name' => ucfirst($this->faker->unique()->word()),
+            'category_id' => SkillCategory::factory(),
+            'level' => $this->faker->numberBetween(40, 100),
+            'sort_order' => $this->faker->numberBetween(1, 100),
+        ];
+    }
+
+    public function withoutCategory(): self
+    {
+        return $this->state(fn () => [
+            'category_id' => null,
+        ]);
+    }
+}

--- a/apps/api/database/factories/TagFactory.php
+++ b/apps/api/database/factories/TagFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Tag;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<Tag>
+ */
+class TagFactory extends Factory
+{
+    protected $model = Tag::class;
+
+    public function definition(): array
+    {
+        $name = $this->faker->unique()->words(2, true);
+
+        return [
+            'name' => ucfirst($name),
+            'slug' => Str::slug($name) . '-' . Str::random(4),
+        ];
+    }
+}

--- a/apps/api/routes/api.php
+++ b/apps/api/routes/api.php
@@ -1,10 +1,29 @@
 <?php
 
-use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\ProfileController;
+use App\Http\Controllers\Api\PostController;
+use App\Http\Controllers\Api\ProjectController;
+use App\Http\Controllers\Api\SeriesController;
+use App\Http\Controllers\Api\SkillController;
+use App\Http\Controllers\Api\TagController;
 
 /**
  * Endpoints públicos
  */
 Route::get('/profile', [ProfileController::class, 'show']);
+
+Route::get('/posts', [PostController::class, 'index']);
+Route::get('/posts/{post:slug}', [PostController::class, 'show']);
+
+Route::get('/projects', [ProjectController::class, 'index']);
+Route::get('/projects/{project:slug}', [ProjectController::class, 'show']);
+
+Route::get('/skills', [SkillController::class, 'index']);
+Route::get('/skills/{skill}', [SkillController::class, 'show']);
+
+Route::get('/tags', [TagController::class, 'index']);
+Route::get('/tags/{tag:slug}', [TagController::class, 'show']);
+
+Route::get('/series', [SeriesController::class, 'index']);
+Route::get('/series/{series:slug}', [SeriesController::class, 'show']);

--- a/apps/api/tests/CreatesApplication.php
+++ b/apps/api/tests/CreatesApplication.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Tests;
+
+use Illuminate\Contracts\Console\Kernel;
+use Illuminate\Foundation\Application;
+
+trait CreatesApplication
+{
+    protected function createApplication(): Application
+    {
+        $app = require __DIR__.'/../bootstrap/app.php';
+
+        $app->make(Kernel::class)->bootstrap();
+
+        return $app;
+    }
+}

--- a/apps/api/tests/Feature/Api/PostApiTest.php
+++ b/apps/api/tests/Feature/Api/PostApiTest.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use App\Models\Post;
+use App\Models\Series;
+use App\Models\Tag;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class PostApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_lists_only_published_posts_by_default(): void
+    {
+        $published = Post::factory()->published()->create(['title' => 'Visible Post']);
+        Post::factory()->create(['title' => 'Hidden Draft']);
+        Post::factory()->published()->create(['published_at' => now()->addDay()]);
+
+        $response = $this->getJson('/api/posts');
+
+        $response->assertOk()
+            ->assertJsonPath('status', 'success')
+            ->assertJsonCount(1, 'data')
+            ->assertJsonPath('data.0.slug', $published->slug);
+    }
+
+    public function test_it_filters_posts_by_tag_slug(): void
+    {
+        $tag = Tag::factory()->create(['slug' => 'laravel']);
+        $matching = Post::factory()->published()->create();
+        $matching->tags()->attach($tag);
+
+        Post::factory()->published()->create();
+
+        $response = $this->getJson('/api/posts?tag=laravel');
+
+        $response->assertOk()
+            ->assertJsonCount(1, 'data')
+            ->assertJsonPath('data.0.id', $matching->id);
+    }
+
+    public function test_it_allows_status_filter_for_drafts(): void
+    {
+        $draft = Post::factory()->create(['title' => 'Drafted']);
+        Post::factory()->published()->create();
+
+        $response = $this->getJson('/api/posts?status=draft');
+
+        $response->assertOk()
+            ->assertJsonCount(1, 'data')
+            ->assertJsonPath('data.0.slug', $draft->slug);
+    }
+
+    public function test_it_supports_searching_content(): void
+    {
+        $target = Post::factory()->published()->create(['title' => 'API Tips and Tricks']);
+        Post::factory()->published()->create(['title' => 'Another Article']);
+
+        $response = $this->getJson('/api/posts?search=Tips');
+
+        $response->assertOk()
+            ->assertJsonCount(1, 'data')
+            ->assertJsonPath('data.0.id', $target->id);
+    }
+
+    public function test_it_shows_single_post_when_available(): void
+    {
+        $series = Series::factory()->create(['title' => 'Backend']);
+        $tag = Tag::factory()->create(['name' => 'PHP']);
+        $post = Post::factory()->published()->create([
+            'slug' => 'laravel-api',
+            'series_id' => $series->id,
+        ]);
+        $post->tags()->attach($tag);
+
+        $response = $this->getJson('/api/posts/laravel-api');
+
+        $response->assertOk()
+            ->assertJsonPath('data.title', $post->title)
+            ->assertJsonPath('data.series.title', 'Backend')
+            ->assertJsonPath('data.tags.0.name', 'PHP');
+    }
+
+    public function test_it_returns_404_for_draft_post_without_status_override(): void
+    {
+        $post = Post::factory()->create(['slug' => 'hidden-post']);
+
+        $this->getJson('/api/posts/hidden-post')->assertNotFound();
+
+        $this->getJson('/api/posts/hidden-post?status=draft')
+            ->assertOk()
+            ->assertJsonPath('data.slug', 'hidden-post');
+    }
+}

--- a/apps/api/tests/Feature/Api/ProjectApiTest.php
+++ b/apps/api/tests/Feature/Api/ProjectApiTest.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use App\Models\Project;
+use App\Models\ProjectBlock;
+use App\Models\Skill;
+use App\Models\Tag;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ProjectApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_lists_only_published_projects_by_default(): void
+    {
+        $visible = Project::factory()->published()->create(['title' => 'Portfolio']);
+        Project::factory()->create(['title' => 'Draft Project']);
+        Project::factory()->published()->create(['published_at' => now()->addDays(2)]);
+
+        $response = $this->getJson('/api/projects');
+
+        $response->assertOk()
+            ->assertJsonCount(1, 'data')
+            ->assertJsonPath('data.0.slug', $visible->slug);
+    }
+
+    public function test_it_filters_projects_by_skill_identifier(): void
+    {
+        $skill = Skill::factory()->create(['name' => 'Laravel']);
+        $matching = Project::factory()->published()->create();
+        $matching->skills()->attach($skill);
+
+        Project::factory()->published()->create();
+
+        $response = $this->getJson('/api/projects?skill=' . $skill->id);
+
+        $response->assertOk()
+            ->assertJsonCount(1, 'data')
+            ->assertJsonPath('data.0.id', $matching->id);
+    }
+
+    public function test_it_filters_projects_by_tag_slug(): void
+    {
+        $tag = Tag::factory()->create(['slug' => 'fullstack']);
+        $matching = Project::factory()->published()->create();
+        $matching->tags()->attach($tag);
+
+        Project::factory()->published()->create();
+
+        $response = $this->getJson('/api/projects?tag=fullstack');
+
+        $response->assertOk()
+            ->assertJsonCount(1, 'data')
+            ->assertJsonPath('data.0.id', $matching->id);
+    }
+
+    public function test_it_supports_project_search(): void
+    {
+        $target = Project::factory()->published()->create(['summary' => 'Building a public API']);
+        Project::factory()->published()->create(['summary' => 'Another project']);
+
+        $response = $this->getJson('/api/projects?search=public API');
+
+        $response->assertOk()
+            ->assertJsonCount(1, 'data')
+            ->assertJsonPath('data.0.id', $target->id);
+    }
+
+    public function test_it_shows_project_with_related_information(): void
+    {
+        $project = Project::factory()->published()->create(['slug' => 'awesome-project']);
+        $skill = Skill::factory()->create(['name' => 'PHP']);
+        $tag = Tag::factory()->create(['name' => 'Backend']);
+        $project->skills()->attach($skill);
+        $project->tags()->attach($tag);
+        ProjectBlock::factory()->for($project)->create(['type' => 'text', 'order_index' => 1]);
+
+        $response = $this->getJson('/api/projects/awesome-project');
+
+        $response->assertOk()
+            ->assertJsonPath('data.title', $project->title)
+            ->assertJsonPath('data.skills.0.name', 'PHP')
+            ->assertJsonPath('data.tags.0.name', 'Backend')
+            ->assertJsonPath('data.blocks.0.type', 'text');
+    }
+
+    public function test_it_returns_404_for_draft_project_without_status_override(): void
+    {
+        $project = Project::factory()->create(['slug' => 'secret-project']);
+
+        $this->getJson('/api/projects/secret-project')->assertNotFound();
+
+        $this->getJson('/api/projects/secret-project?status=draft')
+            ->assertOk()
+            ->assertJsonPath('data.slug', 'secret-project');
+    }
+}

--- a/apps/api/tests/Feature/Api/SeriesApiTest.php
+++ b/apps/api/tests/Feature/Api/SeriesApiTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use App\Models\Post;
+use App\Models\Series;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class SeriesApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_lists_series_with_counts(): void
+    {
+        $series = Series::factory()->create(['title' => 'APIs']);
+        Post::factory()->published()->create(['series_id' => $series->id]);
+        Series::factory()->create();
+
+        $response = $this->getJson('/api/series?include_counts=1');
+
+        $response->assertOk()
+            ->assertJsonCount(2, 'data');
+
+        $payload = collect($response->json('data'))->firstWhere('slug', $series->slug);
+        $this->assertSame(1, $payload['posts_count']);
+    }
+
+    public function test_it_supports_searching_series(): void
+    {
+        Series::factory()->create(['title' => 'API Series']);
+        Series::factory()->create(['title' => 'Other']);
+
+        $response = $this->getJson('/api/series?search=API');
+
+        $response->assertOk()
+            ->assertJsonCount(1, 'data');
+    }
+
+    public function test_it_shows_series_with_posts(): void
+    {
+        $series = Series::factory()->create(['slug' => 'backend']);
+        $post = Post::factory()->published()->create(['series_id' => $series->id, 'title' => 'REST APIs']);
+
+        $response = $this->getJson('/api/series/backend?include=posts');
+
+        $response->assertOk()
+            ->assertJsonPath('data.title', $series->title)
+            ->assertJsonPath('data.posts.0.title', 'REST APIs');
+    }
+}

--- a/apps/api/tests/Feature/Api/SkillApiTest.php
+++ b/apps/api/tests/Feature/Api/SkillApiTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use App\Models\Project;
+use App\Models\Skill;
+use App\Models\SkillCategory;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class SkillApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_lists_skills_with_categories(): void
+    {
+        Skill::factory()->count(2)->create();
+
+        $response = $this->getJson('/api/skills?include=category&include_counts=1');
+
+        $response->assertOk()
+            ->assertJsonPath('status', 'success')
+            ->assertJsonCount(2, 'data')
+            ->assertNotNull($response->json('data.0.category'));
+    }
+
+    public function test_it_filters_skills_by_category_identifier(): void
+    {
+        $category = SkillCategory::factory()->create();
+        $matching = Skill::factory()->create(['category_id' => $category->id]);
+        Skill::factory()->create();
+
+        $response = $this->getJson('/api/skills?category=' . $category->id);
+
+        $response->assertOk()
+            ->assertJsonCount(1, 'data')
+            ->assertJsonPath('data.0.id', $matching->id);
+    }
+
+    public function test_it_filters_skills_without_category(): void
+    {
+        $withoutCategory = Skill::factory()->withoutCategory()->create();
+        Skill::factory()->create();
+
+        $response = $this->getJson('/api/skills?category=none');
+
+        $response->assertOk()
+            ->assertJsonCount(1, 'data')
+            ->assertJsonPath('data.0.id', $withoutCategory->id);
+    }
+
+    public function test_it_shows_skill_with_projects(): void
+    {
+        $skill = Skill::factory()->create();
+        $project = Project::factory()->published()->create(['title' => 'API Project']);
+        $project->skills()->attach($skill);
+
+        $response = $this->getJson('/api/skills/' . $skill->id . '?include=projects');
+
+        $response->assertOk()
+            ->assertJsonPath('data.name', $skill->name)
+            ->assertJsonPath('data.projects.0.title', 'API Project');
+    }
+}

--- a/apps/api/tests/Feature/Api/TagApiTest.php
+++ b/apps/api/tests/Feature/Api/TagApiTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use App\Models\Post;
+use App\Models\Project;
+use App\Models\Tag;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class TagApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_lists_tags_with_counts(): void
+    {
+        $tag = Tag::factory()->create(['name' => 'API']);
+        $post = Post::factory()->published()->create();
+        $project = Project::factory()->published()->create();
+        $post->tags()->attach($tag);
+        $project->tags()->attach($tag);
+
+        Tag::factory()->create();
+
+        $response = $this->getJson('/api/tags?include_counts=1');
+
+        $response->assertOk()
+            ->assertJsonCount(2, 'data');
+
+        $payload = collect($response->json('data'))->firstWhere('slug', $tag->slug);
+        $this->assertNotNull($payload);
+        $this->assertSame(1, $payload['posts_count']);
+        $this->assertSame(1, $payload['projects_count']);
+    }
+
+    public function test_it_filters_tags_by_content_type(): void
+    {
+        $postTag = Tag::factory()->create(['slug' => 'articles']);
+        $projectTag = Tag::factory()->create(['slug' => 'apps']);
+        Post::factory()->published()->create()->tags()->attach($postTag);
+        Project::factory()->published()->create()->tags()->attach($projectTag);
+
+        $response = $this->getJson('/api/tags?type=posts');
+
+        $response->assertOk()
+            ->assertJsonCount(1, 'data')
+            ->assertJsonPath('data.0.slug', 'articles');
+    }
+
+    public function test_it_shows_tag_with_related_entries(): void
+    {
+        $tag = Tag::factory()->create(['slug' => 'backend']);
+        $post = Post::factory()->published()->create(['title' => 'Building APIs']);
+        $project = Project::factory()->published()->create(['title' => 'API Platform']);
+        $post->tags()->attach($tag);
+        $project->tags()->attach($tag);
+
+        $response = $this->getJson('/api/tags/backend?include=posts,projects');
+
+        $response->assertOk()
+            ->assertJsonPath('data.posts.0.title', 'Building APIs')
+            ->assertJsonPath('data.projects.0.title', 'API Platform');
+    }
+}

--- a/apps/api/tests/TestCase.php
+++ b/apps/api/tests/TestCase.php
@@ -6,5 +6,5 @@ use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 
 abstract class TestCase extends BaseTestCase
 {
-    //
+    use CreatesApplication;
 }


### PR DESCRIPTION
## Summary
- implement new public API controllers for posts, projects, tags, skills, and series backed by shared query-filter helpers to expose searchable listings
- add dedicated JSON resources and model updates so responses include consistent metadata plus published scopes and factory support
- create factories and feature tests that exercise the new endpoints for posts, projects, skills, tags, and series

## Testing
- `composer install --prefer-source --no-interaction` *(fails: GitHub 403 prevents downloading dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68d3789a14f8832e873e2476c30bf835