### PR TITLE
feat: scaffold liquidaciones module UI

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -6,9 +6,16 @@
         "build": "vite build",
         "dev": "vite"
     },
+    "dependencies": {
+        "axios": "^1.11.0",
+        "daisyui": "^4.12.13",
+        "react": "^19.0.0-rc",
+        "react-dom": "^19.0.0-rc",
+        "zustand": "^4.5.4"
+    },
     "devDependencies": {
         "@tailwindcss/vite": "^4.0.0",
-        "axios": "^1.11.0",
+        "@vitejs/plugin-react": "^4.3.4",
         "concurrently": "^9.0.1",
         "laravel-vite-plugin": "^2.0.0",
         "tailwindcss": "^4.0.0",

--- a/apps/api/resources/css/app.css
+++ b/apps/api/resources/css/app.css
@@ -1,4 +1,5 @@
 @import 'tailwindcss';
+@plugin "daisyui";
 
 @source '../../vendor/laravel/framework/src/Illuminate/Pagination/resources/views/*.blade.php';
 @source '../../storage/framework/views/*.php';

--- a/apps/api/resources/js/app.js
+++ b/apps/api/resources/js/app.js
@@ -1,1 +1,0 @@
-import './bootstrap';

--- a/apps/api/resources/js/app.jsx
+++ b/apps/api/resources/js/app.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import './bootstrap';
+import LiquidacionesPage from './features/liquidaciones/pages/LiquidacionesPage';
+
+const container = document.getElementById('app-root');
+
+if (container) {
+    createRoot(container).render(
+        <React.StrictMode>
+            <LiquidacionesPage />
+        </React.StrictMode>,
+    );
+}

--- a/apps/api/resources/js/features/liquidaciones/components/LiquidacionStatusBadge.jsx
+++ b/apps/api/resources/js/features/liquidaciones/components/LiquidacionStatusBadge.jsx
@@ -1,0 +1,14 @@
+const STATUS_STYLES = {
+    Pendiente: 'badge-warning text-warning-content',
+    'En Revisión': 'badge-info text-info-content',
+    Aprobada: 'badge-success text-success-content',
+    Rechazada: 'badge-error text-error-content',
+};
+
+const LiquidacionStatusBadge = ({ estado }) => {
+    const style = STATUS_STYLES[estado] ?? 'badge-ghost';
+
+    return <span className={`badge font-medium ${style}`}>{estado}</span>;
+};
+
+export default LiquidacionStatusBadge;

--- a/apps/api/resources/js/features/liquidaciones/components/LiquidacionesTable.jsx
+++ b/apps/api/resources/js/features/liquidaciones/components/LiquidacionesTable.jsx
@@ -1,0 +1,68 @@
+import LiquidacionStatusBadge from './LiquidacionStatusBadge';
+
+const formatter = new Intl.NumberFormat('es-AR', {
+    style: 'currency',
+    currency: 'ARS',
+    minimumFractionDigits: 2,
+});
+
+const LiquidacionesTable = ({ liquidaciones }) => {
+    if (!liquidaciones.length) {
+        return (
+            <div className="card bg-base-100 shadow-sm border border-base-200">
+                <div className="card-body items-center text-center">
+                    <h3 className="card-title text-base-content/80">No se encontraron liquidaciones</h3>
+                    <p className="text-base-content/60 text-sm">
+                        Ajusta los filtros o crea una nueva liquidación para comenzar.
+                    </p>
+                </div>
+            </div>
+        );
+    }
+
+    return (
+        <div className="overflow-x-auto rounded-xl border border-base-200 shadow-sm bg-base-100">
+            <table className="table">
+                <thead>
+                    <tr className="text-sm text-base-content/60">
+                        <th>Asociación</th>
+                        <th className="text-right">Monto asignado</th>
+                        <th className="text-right">Monto gastado</th>
+                        <th>Estado</th>
+                        <th className="text-right">Fecha presentación</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {liquidaciones.map((liquidacion) => (
+                        <tr key={liquidacion.id} className="hover:bg-base-200/50">
+                            <td>
+                                <div className="flex flex-col">
+                                    <span className="font-semibold text-base-content">{liquidacion.asociacion}</span>
+                                    <span className="text-xs text-base-content/60">ID: {liquidacion.id}</span>
+                                </div>
+                            </td>
+                            <td className="text-right font-medium text-base-content">
+                                {formatter.format(liquidacion.montoAsignado)}
+                            </td>
+                            <td className="text-right text-base-content">
+                                {formatter.format(liquidacion.montoGastado)}
+                            </td>
+                            <td>
+                                <LiquidacionStatusBadge estado={liquidacion.estado} />
+                            </td>
+                            <td className="text-right text-base-content/70">
+                                {new Date(liquidacion.fechaPresentacion).toLocaleDateString('es-AR', {
+                                    day: '2-digit',
+                                    month: '2-digit',
+                                    year: 'numeric',
+                                })}
+                            </td>
+                        </tr>
+                    ))}
+                </tbody>
+            </table>
+        </div>
+    );
+};
+
+export default LiquidacionesTable;

--- a/apps/api/resources/js/features/liquidaciones/components/NuevaLiquidacionModal.jsx
+++ b/apps/api/resources/js/features/liquidaciones/components/NuevaLiquidacionModal.jsx
@@ -1,0 +1,82 @@
+const NuevaLiquidacionModal = ({ isOpen, onClose }) => {
+    if (!isOpen) {
+        return null;
+    }
+
+    return (
+        <dialog className="modal modal-open">
+            <div className="modal-box max-w-2xl">
+                <div className="flex items-start justify-between gap-4">
+                    <div>
+                        <h3 className="font-bold text-lg text-base-content">Nueva liquidación</h3>
+                        <p className="text-sm text-base-content/70 mt-1">
+                            Completa la información para registrar la rendición de gastos de la asociación.
+                        </p>
+                    </div>
+                    <button className="btn btn-sm btn-circle btn-ghost" onClick={onClose} type="button">
+                        ✕
+                    </button>
+                </div>
+                <div className="divider my-4" />
+                <form className="space-y-4">
+                    <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                        <label className="form-control">
+                            <div className="label">
+                                <span className="label-text">Asociación</span>
+                                <span className="label-text-alt text-error">*</span>
+                            </div>
+                            <input type="text" className="input input-bordered" placeholder="Selecciona una asociación" />
+                        </label>
+                        <label className="form-control">
+                            <div className="label">
+                                <span className="label-text">Fecha de presentación</span>
+                                <span className="label-text-alt text-error">*</span>
+                            </div>
+                            <input type="date" className="input input-bordered" />
+                        </label>
+                        <label className="form-control">
+                            <div className="label">
+                                <span className="label-text">Monto asignado</span>
+                                <span className="label-text-alt text-error">*</span>
+                            </div>
+                            <input type="number" min="0" className="input input-bordered" placeholder="0,00" />
+                        </label>
+                        <label className="form-control">
+                            <div className="label">
+                                <span className="label-text">Monto gastado</span>
+                                <span className="label-text-alt text-error">*</span>
+                            </div>
+                            <input type="number" min="0" className="input input-bordered" placeholder="0,00" />
+                        </label>
+                    </div>
+                    <label className="form-control">
+                        <div className="label">
+                            <span className="label-text">Observaciones</span>
+                            <span className="label-text-alt text-base-content/50">Opcional</span>
+                        </div>
+                        <textarea className="textarea textarea-bordered min-h-28" placeholder="Describe el detalle de la rendición" />
+                    </label>
+                    <div className="alert alert-info text-sm">
+                        <span>
+                            En esta fase la información es de referencia. En la etapa de integración se conectará con la API
+                            oficial.
+                        </span>
+                    </div>
+                </form>
+                <div className="modal-action mt-6">
+                    <button className="btn btn-ghost" type="button" onClick={onClose}>
+                        Cancelar
+                    </button>
+                    <button className="btn btn-primary" type="button">
+                        Guardar borrador
+                    </button>
+                </div>
+            </div>
+            <form method="dialog" className="modal-backdrop">
+                <button onClick={onClose}>Cerrar</button>
+            </form>
+        </dialog>
+    );
+};
+
+export default NuevaLiquidacionModal;

--- a/apps/api/resources/js/features/liquidaciones/data/mockLiquidaciones.js
+++ b/apps/api/resources/js/features/liquidaciones/data/mockLiquidaciones.js
@@ -1,0 +1,44 @@
+const mockLiquidaciones = [
+    {
+        id: 'liq-001',
+        asociacion: 'Asociación Cultural Raíces',
+        montoAsignado: 25000,
+        montoGastado: 17850,
+        estado: 'Pendiente',
+        fechaPresentacion: '2024-09-12',
+    },
+    {
+        id: 'liq-002',
+        asociacion: 'Club Deportivo Horizonte',
+        montoAsignado: 42000,
+        montoGastado: 42000,
+        estado: 'En Revisión',
+        fechaPresentacion: '2024-09-08',
+    },
+    {
+        id: 'liq-003',
+        asociacion: 'Fundación Manos Solidarias',
+        montoAsignado: 31000,
+        montoGastado: 28950,
+        estado: 'Aprobada',
+        fechaPresentacion: '2024-08-28',
+    },
+    {
+        id: 'liq-004',
+        asociacion: 'Asociación Vecinal Los Pinos',
+        montoAsignado: 18000,
+        montoGastado: 19650,
+        estado: 'Rechazada',
+        fechaPresentacion: '2024-08-18',
+    },
+    {
+        id: 'liq-005',
+        asociacion: 'Cooperativa Juvenil Impulso',
+        montoAsignado: 28000,
+        montoGastado: 21000,
+        estado: 'Pendiente',
+        fechaPresentacion: '2024-09-15',
+    },
+];
+
+export default mockLiquidaciones;

--- a/apps/api/resources/js/features/liquidaciones/pages/LiquidacionesPage.jsx
+++ b/apps/api/resources/js/features/liquidaciones/pages/LiquidacionesPage.jsx
@@ -1,0 +1,75 @@
+import useLiquidaciones from '@/hooks/useLiquidaciones';
+import LiquidacionesTable from '../components/LiquidacionesTable';
+import NuevaLiquidacionModal from '../components/NuevaLiquidacionModal';
+
+const estadoOptions = ['todas', 'Pendiente', 'En Revisión', 'Aprobada', 'Rechazada'];
+
+const LiquidacionesPage = () => {
+    const { liquidaciones, filters, setFilters, resetFilters, openModal, closeModal, isModalOpen } = useLiquidaciones();
+
+    return (
+        <div className="min-h-screen bg-base-200">
+            <header className="border-b border-base-300 bg-base-100">
+                <div className="max-w-6xl mx-auto px-4 py-6 flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+                    <div>
+                        <p className="text-sm uppercase tracking-widest text-primary font-semibold">Gestión de asociaciones</p>
+                        <h1 className="text-3xl font-bold text-base-content">Liquidación de asignaciones</h1>
+                        <p className="text-base-content/70 text-sm mt-1">
+                            Visualiza el estado de las rendiciones pendientes, aprueba gastos y registra nuevas liquidaciones.
+                        </p>
+                    </div>
+                    <button className="btn btn-primary btn-wide md:btn-md md:w-auto" onClick={openModal} type="button">
+                        Nueva liquidación
+                    </button>
+                </div>
+            </header>
+            <main className="max-w-6xl mx-auto px-4 py-8 space-y-6">
+                <section className="card bg-base-100 border border-base-200 shadow-sm">
+                    <div className="card-body gap-6">
+                        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+                            <label className="form-control">
+                                <div className="label">
+                                    <span className="label-text font-semibold text-base-content">Buscar asociación</span>
+                                </div>
+                                <input
+                                    className="input input-bordered"
+                                    placeholder="Ej. Fundación Manos Solidarias"
+                                    type="search"
+                                    value={filters.search}
+                                    onChange={(event) => setFilters({ search: event.target.value })}
+                                />
+                            </label>
+                            <label className="form-control">
+                                <div className="label">
+                                    <span className="label-text font-semibold text-base-content">Estado</span>
+                                </div>
+                                <select
+                                    className="select select-bordered"
+                                    value={filters.estado}
+                                    onChange={(event) => setFilters({ estado: event.target.value })}
+                                >
+                                    {estadoOptions.map((option) => (
+                                        <option key={option} value={option}>
+                                            {option === 'todas' ? 'Todas' : option}
+                                        </option>
+                                    ))}
+                                </select>
+                            </label>
+                            <div className="flex items-end">
+                                <button className="btn btn-outline w-full md:w-auto" type="button" onClick={resetFilters}>
+                                    Limpiar filtros
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+                </section>
+                <section>
+                    <LiquidacionesTable liquidaciones={liquidaciones} />
+                </section>
+            </main>
+            <NuevaLiquidacionModal isOpen={isModalOpen} onClose={closeModal} />
+        </div>
+    );
+};
+
+export default LiquidacionesPage;

--- a/apps/api/resources/js/hooks/useLiquidaciones.js
+++ b/apps/api/resources/js/hooks/useLiquidaciones.js
@@ -1,0 +1,60 @@
+import { useEffect, useMemo } from 'react';
+import useLiquidacionesStore from '../stores/liquidacionesStore';
+
+const normalize = (value) => value.toLowerCase();
+
+const matchesSearch = (liquidacion, search) => {
+    if (!search) {
+        return true;
+    }
+
+    const query = normalize(search);
+    return normalize(liquidacion.asociacion).includes(query);
+};
+
+const matchesEstado = (liquidacion, estado) => {
+    if (estado === 'todas') {
+        return true;
+    }
+
+    return liquidacion.estado === estado;
+};
+
+const useLiquidaciones = () => {
+    const liquidaciones = useLiquidacionesStore((state) => state.liquidaciones);
+    const fetchStatus = useLiquidacionesStore((state) => state.fetchStatus);
+    const hydrateMock = useLiquidacionesStore((state) => state.hydrateMock);
+    const filters = useLiquidacionesStore((state) => state.filters);
+    const setFilters = useLiquidacionesStore((state) => state.setFilters);
+    const resetFilters = useLiquidacionesStore((state) => state.resetFilters);
+    const isModalOpen = useLiquidacionesStore((state) => state.isModalOpen);
+    const openModal = useLiquidacionesStore((state) => state.openModal);
+    const closeModal = useLiquidacionesStore((state) => state.closeModal);
+
+    useEffect(() => {
+        if (fetchStatus === 'idle') {
+            hydrateMock();
+        }
+    }, [fetchStatus, hydrateMock]);
+
+    const filteredLiquidaciones = useMemo(() => {
+        return liquidaciones.filter(
+            (liquidacion) =>
+                matchesSearch(liquidacion, filters.search) &&
+                matchesEstado(liquidacion, filters.estado),
+        );
+    }, [liquidaciones, filters]);
+
+    return {
+        liquidaciones: filteredLiquidaciones,
+        fetchStatus,
+        filters,
+        setFilters,
+        resetFilters,
+        isModalOpen,
+        openModal,
+        closeModal,
+    };
+};
+
+export default useLiquidaciones;

--- a/apps/api/resources/js/services/apiClient.js
+++ b/apps/api/resources/js/services/apiClient.js
@@ -1,0 +1,22 @@
+import axios from 'axios';
+
+const apiClient = axios.create({
+    baseURL: import.meta.env.VITE_API_BASE_URL ?? '/api',
+    headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+    },
+});
+
+apiClient.interceptors.request.use((config) => {
+    return config;
+});
+
+apiClient.interceptors.response.use(
+    (response) => response,
+    (error) => {
+        return Promise.reject(error);
+    },
+);
+
+export default apiClient;

--- a/apps/api/resources/js/services/liquidacionesService.js
+++ b/apps/api/resources/js/services/liquidacionesService.js
@@ -1,0 +1,20 @@
+import apiClient from './apiClient';
+import mockLiquidaciones from '../features/liquidaciones/data/mockLiquidaciones';
+
+export const fetchLiquidaciones = async ({ useMock = import.meta.env.DEV } = {}) => {
+    if (useMock) {
+        return mockLiquidaciones;
+    }
+
+    const { data } = await apiClient.get('/liquidaciones');
+    return data;
+};
+
+export const createLiquidacion = async (payload, { useMock = import.meta.env.DEV } = {}) => {
+    if (useMock) {
+        return { ...payload, id: crypto.randomUUID(), estado: 'Pendiente' };
+    }
+
+    const { data } = await apiClient.post('/liquidaciones', payload);
+    return data;
+};

--- a/apps/api/resources/js/stores/liquidacionesStore.js
+++ b/apps/api/resources/js/stores/liquidacionesStore.js
@@ -1,0 +1,35 @@
+import { create } from 'zustand';
+import mockLiquidaciones from '../features/liquidaciones/data/mockLiquidaciones';
+
+const initialFilters = {
+    search: '',
+    estado: 'todas',
+};
+
+const initialState = {
+    liquidaciones: [],
+    fetchStatus: 'idle',
+    filters: { ...initialFilters },
+    isModalOpen: false,
+};
+
+const useLiquidacionesStore = create((set) => ({
+    ...initialState,
+    hydrateMock: () =>
+        set(() => ({
+            liquidaciones: mockLiquidaciones,
+            fetchStatus: 'success',
+        })),
+    openModal: () => set({ isModalOpen: true }),
+    closeModal: () => set({ isModalOpen: false }),
+    setFilters: (filters) =>
+        set((state) => ({
+            filters: {
+                ...state.filters,
+                ...filters,
+            },
+        })),
+    resetFilters: () => set({ filters: { ...initialFilters } }),
+}));
+
+export default useLiquidacionesStore;

--- a/apps/api/resources/views/app.blade.php
+++ b/apps/api/resources/views/app.blade.php
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <title>Liquidaciones de asignaciones</title>
+        <link rel="preconnect" href="https://fonts.bunny.net">
+        <link href="https://fonts.bunny.net/css?family=instrument-sans:400,500,600,700" rel="stylesheet" />
+        @viteReactRefresh
+        @vite(['resources/css/app.css', 'resources/js/app.jsx'])
+    </head>
+    <body class="bg-base-200 text-base-content">
+        <div id="app-root"></div>
+    </body>
+</html>

--- a/apps/api/routes/web.php
+++ b/apps/api/routes/web.php
@@ -7,5 +7,7 @@ Route::get('/', function () {
     return view('welcome');
 });
 
+Route::view('/liquidaciones', 'app')->name('liquidaciones.index');
+
 Route::get('/preview/{token}', [PreviewController::class, 'show'])
     ->name('preview.show'); // sin auth, noindex en la vista

--- a/apps/api/vite.config.js
+++ b/apps/api/vite.config.js
@@ -1,13 +1,25 @@
 import { defineConfig } from 'vite';
 import laravel from 'laravel-vite-plugin';
 import tailwindcss from '@tailwindcss/vite';
+import react from '@vitejs/plugin-react';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
 
 export default defineConfig({
     plugins: [
         laravel({
-            input: ['resources/css/app.css', 'resources/js/app.js'],
+            input: ['resources/css/app.css', 'resources/js/app.jsx'],
             refresh: true,
         }),
+        react(),
         tailwindcss(),
     ],
+    resolve: {
+        alias: {
+            '@': resolve(__dirname, 'resources/js'),
+        },
+    },
 });


### PR DESCRIPTION
## Summary
- configure Vite with the React plugin, Tailwind + DaisyUI, and add runtime dependencies required for the new frontend stack
- scaffold the Liquidaciones page with filters, data table, and modal form backed by a Zustand store and mock data
- add reusable services, hooks, and views to bootstrap future integration phases for the liquidaciones module

## Testing
- npm install *(fails: 403 Forbidden while downloading @vitejs/plugin-react)*

------
https://chatgpt.com/codex/tasks/task_e_68dd376b04f0832e96cec046a165c4be